### PR TITLE
Add Encoding: UTF-8

### DIFF
--- a/LPJmLmdi/DESCRIPTION
+++ b/LPJmLmdi/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: LPJmLmdi
 Title: Model-Data Integration for the LPJmL Dynamic Global Vegetation Model
-Version: 1.3
+Version: 1.3.1
 Date: 2019-01-22
 Author: Matthias Forkel <matthias.forkel@geo.tuwien.ac.at> [aut, cre], Markus Drüke <drueke@pik-potsdam.de> [aut]
 Maintainer: Matthias Forkel <matthias.forkel@geo.tuwien.ac.at>, Markus Drüke <drueke@pik-potsdam.de>
@@ -8,5 +8,5 @@ Description: Model-data integration framework for the LPJmL dynamic global veget
 Depends: R (>= 2.15.3), raster, plyr, rgenoud, ncdf4, ModelDataComp
 Imports: dplyr, plotrix, fields, tidyr
 License: GPL-2
-URL: 
 LazyLoad: yes
+Encoding: UTF-8


### PR DESCRIPTION
When using an UTF-8 locale the following warning is thrown whenever packages are installed/update/listed:
```
Warning messages:
1: In readRDS(file) :
  input string 'Matthias Forkel <matthias.forkel@geo.tuwien.ac.at> [aut, cre], Markus Drüke <drueke@pik-potsdam.de> [aut]' cannot be translated to UTF-8, is it valid in 'ANSI_X3.4-1968'?
2: In readRDS(file) :
  input string 'Matthias Forkel <matthias.forkel@geo.tuwien.ac.at>, Markus Drüke <drueke@pik-potsdam.de>' cannot be translated to UTF-8, is it valid in 'ANSI_X3.4-1968'?
```
Setting the encoding to UTF-8 fixes that.